### PR TITLE
Allow SSL validation to be skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ cat > .config
   "pass": "abc123",
   "org": "cf-sli",
   "space": "dev",
-  "domain": "example.com"
+  "domain": "example.com",
+  "skip_ssl_validation": false
 }
 ```
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,12 +6,13 @@ import (
 )
 
 type Config struct {
-	Api      string `json:"api"`
-	User     string `json:"user"`
-	Password string `json:"pass"`
-	Domain   string `json:"domain"`
-	Org      string `json:"org"`
-	Space    string `json:"space"`
+	Api               string `json:"api"`
+	User              string `json:"user"`
+	Password          string `json:"pass"`
+	Domain            string `json:"domain"`
+	Org               string `json:"org"`
+	Space             string `json:"space"`
+	SkipSslValidation bool   `json:"skip_ssl_validation"`
 }
 
 func (c *Config) LoadConfig(filename string) error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,6 +17,7 @@ var _ = Describe("LoadConfig", func() {
 		Expect(c.Org).To(Equal("fake_org"))
 		Expect(c.Space).To(Equal("fake_space"))
 		Expect(c.Domain).To(Equal("fake_domain"))
+		Expect(c.SkipSslValidation).To(Equal(false))
 	})
 
 	It("returns an error reading a none-existing file", func() {

--- a/sli_executor/sli_executor.go
+++ b/sli_executor/sli_executor.go
@@ -28,8 +28,12 @@ func (s SliExecutor) cf(commands ...string) error {
 	return s.Cf_wrapper.RunCF(commands...)
 }
 
-func (s SliExecutor) Prepare(api string, user string, password string, org string, space string) error {
-	err := s.cf("api", api)
+func (s SliExecutor) Prepare(api string, user string, password string, org string, space string, skipSslValidation bool) error {
+	cfApiArgs := []string{"api", api}
+	if skipSslValidation {
+		cfApiArgs = append(cfApiArgs, "--skip-ssl-validation")
+	}
+	err := s.cf(cfApiArgs...)
 	if err != nil {
 		return err
 	}
@@ -87,7 +91,7 @@ func (s SliExecutor) CleanupSli(app_name string) error {
 func (s SliExecutor) RunTest(app_name string, app_buildpack string, path string, c config.Config) (*Result, error) {
 	defer s.CleanupSli(app_name)
 
-	err := s.Prepare(c.Api, c.User, c.Password, c.Org, c.Space)
+	err := s.Prepare(c.Api, c.User, c.Password, c.Org, c.Space, c.SkipSslValidation)
 	if err != nil {
 		result := &Result{
 			StartStatus: 0,


### PR DESCRIPTION
We would like to be able to use `cf-sli` against a CF deployment with an untrusted certificate. This allows `--skip-ssl-validation` to be passed to `cf api` but defaults to not skipping SSL validation.