### PR TITLE
Allow stack to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ cat > .config
   "org": "cf-sli",
   "space": "dev",
   "domain": "example.com"
+  "domain": "example.com",
+  "stack": "cflinuxfs2"
 }
 ```
 

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	Domain   string `json:"domain"`
 	Org      string `json:"org"`
 	Space    string `json:"space"`
+	Stack    string `json:"stack"`
 }
 
 func (c *Config) LoadConfig(filename string) error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,6 +17,7 @@ var _ = Describe("LoadConfig", func() {
 		Expect(c.Org).To(Equal("fake_org"))
 		Expect(c.Space).To(Equal("fake_space"))
 		Expect(c.Domain).To(Equal("fake_domain"))
+		Expect(c.Stack).To(Equal(""))
 	})
 
 	It("returns an error reading a none-existing file", func() {

--- a/sli_executor/sli_executor.go
+++ b/sli_executor/sli_executor.go
@@ -44,8 +44,12 @@ func (s SliExecutor) Prepare(api string, user string, password string, org strin
 	return nil
 }
 
-func (s SliExecutor) PushAndStartSli(app_name string, app_buildpack string, domain string, path string) (time.Duration, error) {
-	err := s.cf("push", "-p", path, "-b", app_buildpack, app_name, "-d", domain, "--no-start")
+func (s SliExecutor) PushAndStartSli(app_name string, app_buildpack string, domain string, path string, stack string) (time.Duration, error) {
+	cfPushArgs := []string{"push", "-p", path, "-b", app_buildpack, app_name, "-d", domain, "--no-start"}
+	if stack != "" {
+		cfPushArgs = append(cfPushArgs, "-s", stack)
+	}
+	err := s.cf(cfPushArgs...)
 	if err != nil {
 		return time.Duration(0), err
 	}
@@ -96,7 +100,7 @@ func (s SliExecutor) RunTest(app_name string, app_buildpack string, path string,
 		return result, err
 	}
 
-	elapsed_start_time, err := s.PushAndStartSli(app_name, app_buildpack, c.Domain, path)
+	elapsed_start_time, err := s.PushAndStartSli(app_name, app_buildpack, c.Domain, path, c.Stack)
 	if err != nil {
 		result := &Result{
 			StartStatus: 0,


### PR DESCRIPTION
We would like to be able to specify a stack for pushing apps so we can compare performance between different stacks. This adds support for specifying a stack but makes it optional.