### PR TITLE
allow config path to be passed in

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,10 +26,11 @@ func main() {
 	var cf_cli cf_wrapper.CfWrapper
 
 	app_bits_path := flag.String("app-bits", "./assets/ruby_simple", "App bits path")
+	configLocation := flag.String("config", "./config", "Config path")
 
 	flag.Parse()
 
-	err := config.LoadConfig("./.config")
+	err := config.LoadConfig(*configLocation)
 	if err != nil {
 		fmt.Fprint(os.Stderr, "Failed to load .config :\n")
 		fmt.Fprint(os.Stderr, err)


### PR DESCRIPTION
Noticed this just assumed config was in current directory. This change lets you specify a path to the config, or default to the original behavior if the flag isn't set